### PR TITLE
Route Protection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           background: true
       - run:
           name: Run cypress tests
-          command: yarn run cypress run --record
+          command: yarn run cypress run
           environment:
             CYPRESS_baseUrl: http://localhost:5000
             TZ: 'America/New_York'

--- a/cypress/integration/QuestionPage.feature
+++ b/cypress/integration/QuestionPage.feature
@@ -3,7 +3,7 @@ Feature: Question Page
   this morning. When I select a song, I am brought to the Submit Page.
 
   Background:
-    Given it is daytime
+    Given it is day
 
   Scenario: I visit morning cd
     When I visit morning cd

--- a/cypress/integration/QuestionPage.feature
+++ b/cypress/integration/QuestionPage.feature
@@ -64,13 +64,3 @@ Feature: Question Page
     And I click the song "Something Holy" by "Alice Phoebe Lou"
     And I click the browser back button
     Then I am redirected to "/question"
-
-  Scenario Outline: I visit the question page at <timeOfDay>
-    Given it is <timeOfDay>
-    When I visit "/question"
-    Then I am redirected to "/listens"
-
-    Examples:
-      | timeOfDay      |
-      | before sunrise |
-      | after sunset   |

--- a/cypress/integration/QuestionPage.feature
+++ b/cypress/integration/QuestionPage.feature
@@ -64,3 +64,13 @@ Feature: Question Page
     And I click the song "Something Holy" by "Alice Phoebe Lou"
     And I click the browser back button
     Then I am redirected to "/question"
+
+  Scenario Outline: I visit the question page at <timeOfDay>
+    Given it is <timeOfDay>
+    When I visit "/question"
+    Then I am redirected to "/listens"
+
+    Examples:
+      | timeOfDay      |
+      | before sunrise |
+      | after sunset   |

--- a/cypress/integration/QuestionPage/steps.js
+++ b/cypress/integration/QuestionPage/steps.js
@@ -65,10 +65,6 @@ When(`I click the song {string} by {string}`, (name, artist) => {
     .click();
 });
 
-When('I click the browser back button', () => {
-  cy.go('back');
-});
-
 Then(`I see the title {string}`, text => {
   cy.get('h2').contains(text);
 });

--- a/cypress/integration/RouteProtection.feature
+++ b/cypress/integration/RouteProtection.feature
@@ -3,7 +3,7 @@ Feature: Route Protection
   user shouldn't be able to visit the Question Page during the night or if
   the user has already submitted a listen that day.
 
-  Scenario Outline: I visit the day only route /question at <timeOfDay>
+  Scenario Outline: I visit the day only route <route> at <timeOfDay>
     Given it is <timeOfDay>
     When I visit "<route>"
     Then I am redirected to "/listens"

--- a/cypress/integration/RouteProtection.feature
+++ b/cypress/integration/RouteProtection.feature
@@ -14,3 +14,26 @@ Feature: Route Protection
       | /question      | after sunset   |
       | /submit?id=123 | before sunrise |
       | /submit?id=123 | after sunset   |
+
+  Scenario Outline: I visit the route <route> after already submitting a listen today
+    Given it is day
+    And I have submitted a listen today
+    When I visit "<route>"
+    Then I am redirected to "/listens"
+
+    Examples:
+      | route          |
+      | /question      |
+      | /submit?id=123 |
+
+  Scenario Outline: I visit <route> after last submitted a listen days ago
+    Given it is day
+    And I have last submitted a listen a few days ago
+    When I visit "<route>"
+    Then I am still on "<route>"
+
+    Examples:
+      | route          |
+      | /question      |
+      | /submit?id=123 |
+

--- a/cypress/integration/RouteProtection.feature
+++ b/cypress/integration/RouteProtection.feature
@@ -1,0 +1,16 @@
+Feature: Route Protection
+  Some routes should only be accessible under certain conditions. E.g., a
+  user shouldn't be able to visit the Question Page during the night or if
+  the user has already submitted a listen that day.
+
+  Scenario Outline: I visit the day only route /question at <timeOfDay>
+    Given it is <timeOfDay>
+    When I visit "<route>"
+    Then I am redirected to "/listens"
+
+    Examples:
+      | route          | timeOfDay      |
+      | /question      | before sunrise |
+      | /question      | after sunset   |
+      | /submit?id=123 | before sunrise |
+      | /submit?id=123 | after sunset   |

--- a/cypress/integration/RouteProtection.feature
+++ b/cypress/integration/RouteProtection.feature
@@ -28,7 +28,7 @@ Feature: Route Protection
 
   Scenario Outline: I visit <route> after last submitting a listen days ago
     Given it is day
-    And I have last submitted a listen a few days ago
+    And the last time I submitted a listen was a few days ago
     When I visit "<route>"
     Then I am still on "<route>"
 

--- a/cypress/integration/RouteProtection.feature
+++ b/cypress/integration/RouteProtection.feature
@@ -26,7 +26,7 @@ Feature: Route Protection
       | /question      |
       | /submit?id=123 |
 
-  Scenario Outline: I visit <route> after last submitted a listen days ago
+  Scenario Outline: I visit <route> after last submitting a listen days ago
     Given it is day
     And I have last submitted a listen a few days ago
     When I visit "<route>"

--- a/cypress/integration/RouteProtection/steps.js
+++ b/cypress/integration/RouteProtection/steps.js
@@ -1,0 +1,13 @@
+/* global cy Cypress*/
+/// <reference types="cypress" />
+
+beforeEach(() => {
+  cy.graphql({
+    schema: Cypress.env('GRAPHQL_SCHEMA'),
+    endpoint: '/graphql',
+    mocks: {
+      Date: () => '2018-06-12',
+      DateTime: () => '2018-06-11T09:24:32.004423'
+    }
+  });
+});

--- a/cypress/integration/RouteProtection/steps.js
+++ b/cypress/integration/RouteProtection/steps.js
@@ -11,6 +11,13 @@ beforeEach(() => {
       DateTime: () => '2018-06-11T09:24:32.004423'
     }
   });
+  cy.server();
+  cy.route('/accesstoken', 'fixture:morningcd/accessToken.json');
+  cy.route({
+    url: `/v1/tracks/123`,
+    response: 'fixture:spotify/tracks/invalidid.json',
+    status: 400
+  });
 });
 
 Given('I have submitted a listen today', () => {

--- a/cypress/integration/RouteProtection/steps.js
+++ b/cypress/integration/RouteProtection/steps.js
@@ -26,7 +26,7 @@ Given('I have submitted a listen today', () => {
   });
 });
 
-Given('I have last submitted a listen a few days ago', () => {
+Given('the last time I submitted a listen was a few days ago', () => {
   cy.window().then(window => {
     window.localStorage.setItem('lastSubmit', '1985-03-01T12:15:20');
   });

--- a/cypress/integration/RouteProtection/steps.js
+++ b/cypress/integration/RouteProtection/steps.js
@@ -1,5 +1,6 @@
 /* global cy Cypress*/
 /// <reference types="cypress" />
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
 beforeEach(() => {
   cy.graphql({
@@ -9,5 +10,23 @@ beforeEach(() => {
       Date: () => '2018-06-12',
       DateTime: () => '2018-06-11T09:24:32.004423'
     }
+  });
+});
+
+Given('I have submitted a listen today', () => {
+  cy.window().then(window => {
+    window.localStorage.setItem('lastSubmit', '1985-03-05T12:15:20');
+  });
+});
+
+Given('I have last submitted a listen a few days ago', () => {
+  cy.window().then(window => {
+    window.localStorage.setItem('lastSubmit', '1985-03-01T12:15:20');
+  });
+});
+
+Then(`I am still on {string}`, route => {
+  cy.location().then(location => {
+    expect(`${location.pathname}${location.search}`).to.equal(route);
   });
 });

--- a/cypress/integration/SubmitPage.feature
+++ b/cypress/integration/SubmitPage.feature
@@ -60,16 +60,6 @@ Feature: Submit Page
     And I type enter to submit
     Then I am redirected to "/listens"
 
-  Scenario Outline: I visit the question page at <timeOfDay>
-    Given it is <timeOfDay>
-    When I visit "/submit"
-    Then I am redirected to "/listens"
-
-    Examples:
-      | timeOfDay      |
-      | before sunrise |
-      | after sunset   |
-
   Scenario Outline: I am on the submit page with bad query string "<query>" (<description>)
     When I visit "/submit<query>"
     Then I am redirected to "/question"

--- a/cypress/integration/SubmitPage.feature
+++ b/cypress/integration/SubmitPage.feature
@@ -67,7 +67,7 @@ Feature: Submit Page
     And I type "Digging this new vampire weekend song"
     And I hit tab
     And I type enter to submit
-    And I am redirected to "/listens"
+    And I wait for the submit to complete
     And I visit the submit page with the id "3o9lfY9tbv3S00atFxNki5"
     Then I am redirected to "/listens"
 

--- a/cypress/integration/SubmitPage.feature
+++ b/cypress/integration/SubmitPage.feature
@@ -60,7 +60,7 @@ Feature: Submit Page
     And I type enter to submit
     Then I am redirected to "/listens"
 
-  Scenario: I try to visit the submit page after submitting
+  Scenario: I try to visit the submit page after submitting a listen
     When I visit the submit page with the id "3o9lfY9tbv3S00atFxNki5"
     And I type "Zach"
     And I hit tab

--- a/cypress/integration/SubmitPage.feature
+++ b/cypress/integration/SubmitPage.feature
@@ -60,6 +60,17 @@ Feature: Submit Page
     And I type enter to submit
     Then I am redirected to "/listens"
 
+  Scenario: I try to visit the submit page after submitting
+    When I visit the submit page with the id "3o9lfY9tbv3S00atFxNki5"
+    And I type "Zach"
+    And I hit tab
+    And I type "Digging this new vampire weekend song"
+    And I hit tab
+    And I type enter to submit
+    And I am redirected to "/listens"
+    And I visit the submit page with the id "3o9lfY9tbv3S00atFxNki5"
+    Then I am redirected to "/listens"
+
   Scenario Outline: I am on the submit page with bad query string "<query>" (<description>)
     When I visit "/submit<query>"
     Then I am redirected to "/question"

--- a/cypress/integration/SubmitPage.feature
+++ b/cypress/integration/SubmitPage.feature
@@ -3,7 +3,7 @@ Feature: Submit Page
   submit my listen, I am brought to the Listens Page.
 
   Background:
-    Given it is daytime
+    Given it is day
 
   Scenario Outline: I am on the submit page for <name>
     When I visit the submit page with the id "<id>"

--- a/cypress/integration/SubmitPage.feature
+++ b/cypress/integration/SubmitPage.feature
@@ -60,6 +60,16 @@ Feature: Submit Page
     And I type enter to submit
     Then I am redirected to "/listens"
 
+  Scenario Outline: I visit the question page at <timeOfDay>
+    Given it is <timeOfDay>
+    When I visit "/submit"
+    Then I am redirected to "/listens"
+
+    Examples:
+      | timeOfDay      |
+      | before sunrise |
+      | after sunset   |
+
   Scenario Outline: I am on the submit page with bad query string "<query>" (<description>)
     When I visit "/submit<query>"
     Then I am redirected to "/question"

--- a/cypress/integration/SubmitPage/steps.js
+++ b/cypress/integration/SubmitPage/steps.js
@@ -66,6 +66,12 @@ When(`I write the note {string}`, note => {
   cy.get('textarea[data-test=note-input]').type(note);
 });
 
+When('I wait for the submit to complete', () => {
+  // I can't cy.wait on the graphql request using the current mock systen,
+  // so we just wait for the browser to redirect to /listens
+  cy.location('pathname').should('equal', '/listens');
+});
+
 When('I click the submit button', () => {
   cy.get('@graphqlServerError', { log: false }).then(graphqlServerError => {
     cy.get('@songId', { log: false }).then(songId => {

--- a/cypress/integration/common/steps.js
+++ b/cypress/integration/common/steps.js
@@ -68,3 +68,7 @@ Then(`I am redirected to {string} with the params {string}`, (route, params) => 
 Then(`I am redirected to {string}`, route => {
   cy.location('pathname').should('eq', route);
 });
+
+When(/I click the browser (forward|back) button/, direction => {
+  cy.go(direction);
+});

--- a/cypress/integration/common/steps.js
+++ b/cypress/integration/common/steps.js
@@ -38,6 +38,9 @@ Given(/it is (before sunrise|day|after sunset)/, timeOfDay => {
     day: 'Tue Mar 05 1985 13:30:10 GMT-0500',
     'after sunset': 'Tue Mar 05 1985 23:15:40 GMT-0500'
   }[timeOfDay];
+  cy.clock().then(clock => {
+    clock.restore();
+  });
   cy.clock(new Date(currentDateString).getTime(), ['Date']);
 });
 

--- a/cypress/integration/common/steps.js
+++ b/cypress/integration/common/steps.js
@@ -13,17 +13,32 @@ Given('I see the loading cds page', () => {
   cy.get('div[data-test=loading-cds-page]');
 });
 
-Given('it is daytime', () => {
-  // hacky solution that sets all daytime windows span the century,
-  // so that the current time is definitely in today's sunlight window.
+const sunlightWindows = {
+  '1985-03-04': {
+    sunriseUtc: '1985-03-04T11:24:05',
+    sunsetUtc: '1985-03-04T22:51:08'
+  },
+  '1985-03-05': {
+    sunriseUtc: '1985-03-05T11:22:31',
+    sunsetUtc: '1985-03-05T22:52:15'
+  },
+  '1985-03-06': {
+    sunriseUtc: '1985-03-06T11:20:56',
+    sunsetUtc: '1985-03-06T22:53:22'
+  }
+};
+Given(/it is (before sunrise|day|after sunset)/, timeOfDay => {
   cy.graphqlUpdate({
     Query: () => ({
-      sunlightWindow: (_, args) => ({
-        sunriseUtc: '1970-01-01T00:00:00',
-        sunsetUtc: '2070-01-01T00:00:00'
-      })
+      sunlightWindow: (_, args) => sunlightWindows[args.onDate]
     })
   });
+  const currentDateString = {
+    'before sunrise': 'Tue Mar 05 1985 03:50:00 GMT-0500',
+    day: 'Tue Mar 05 1985 13:30:10 GMT-0500',
+    'after sunset': 'Tue Mar 05 1985 23:15:40 GMT-0500'
+  }[timeOfDay];
+  cy.clock(new Date(currentDateString).getTime(), ['Date']);
 });
 
 When(`I visit {string}`, path => {

--- a/src/apollo/index.ts
+++ b/src/apollo/index.ts
@@ -16,6 +16,7 @@ const typeDefs = gql`
     nameInput: String!
     noteInput: String!
     sundial: Sundial!
+    lastSubmit: DateTime
   }
   type Sundial {
     state: SundialState!
@@ -39,6 +40,7 @@ const initialData = {
     questionInput: '',
     noteInput: '',
     nameInput: '',
+    lastSubmit: localStorage.getItem('lastSubmit'),
     sundial: {
       state: 'calibrating',
       lastSunrise: null,

--- a/src/apollo/index.ts
+++ b/src/apollo/index.ts
@@ -19,6 +19,8 @@ const typeDefs = gql`
   }
   type Sundial {
     state: SundialState!
+    # The last sunrise the occurred. Null if state == calibrating.
+    lastSunrise: DateTime
   }
   enum SundialState {
     calibrating
@@ -39,6 +41,7 @@ const initialData = {
     nameInput: '',
     sundial: {
       state: 'calibrating',
+      lastSunrise: null,
       __typename: 'Sundial'
     }
   }

--- a/src/components/ProgressBarLoader/index.tsx
+++ b/src/components/ProgressBarLoader/index.tsx
@@ -1,22 +1,22 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ZeroToOneHundred } from '../ProgressBar/types';
 import ProgressBar from '../ProgressBar';
 
 export default function ProgressBarLoader() {
   const [value, setValue] = useState<ZeroToOneHundred>(0);
-  const intervalRef = useRef<number | undefined>(undefined);
+  const [full, setFull] = useState(false);
   useEffect(() => {
-    const interval = setInterval(() => {
-      setValue(value => (value < 100 ? value + 2 : value) as ZeroToOneHundred);
-    }, 10);
-    intervalRef.current = interval;
-    return () => clearInterval(interval);
-  }, []);
-  useEffect(() => {
-    if (value === 100) {
-      clearInterval(intervalRef.current);
+    if (!full) {
+      const interval = setInterval(() => {
+        setValue(value => {
+          if (value < 100) return Math.min(value + 2, 100) as ZeroToOneHundred;
+          setFull(true);
+          return value;
+        });
+      }, 10);
+      return () => clearInterval(interval);
     }
-  }, [value]);
+  }, [full]);
 
   return <ProgressBar value={value} />;
 }

--- a/src/components/ProgressBarLoader/index.tsx
+++ b/src/components/ProgressBarLoader/index.tsx
@@ -6,9 +6,11 @@ export default function ProgressBarLoader() {
   const [value, setValue] = useState<ZeroToOneHundred>(0);
   const intervalRef = useRef<number | undefined>(undefined);
   useEffect(() => {
-    intervalRef.current = setInterval(() => {
+    const interval = setInterval(() => {
       setValue(value => (value < 100 ? value + 2 : value) as ZeroToOneHundred);
     }, 10);
+    intervalRef.current = interval;
+    return () => clearInterval(interval);
   }, []);
   useEffect(() => {
     if (value === 100) {

--- a/src/hooks/useSubmittedAfterLastSunrise.ts
+++ b/src/hooks/useSubmittedAfterLastSunrise.ts
@@ -1,0 +1,15 @@
+import { useGnomon } from './useSundial';
+import useLocalApolloQuery from './useLocalApolloQuery';
+import gql from 'graphql-tag';
+
+const LAST_SUBMIT_QUERY = gql`
+  query LastSubmit {
+    lastSubmit
+  }
+`;
+
+export default function useSubmittedAfterLastSunrise(): boolean {
+  const [, lastSunrise] = useGnomon();
+  const [{ lastSubmit }] = useLocalApolloQuery<{ lastSubmit: string | null }>(LAST_SUBMIT_QUERY);
+  return Boolean(lastSunrise && lastSubmit && lastSubmit > lastSunrise);
+}

--- a/src/pages/QuestionPage/index.tsx
+++ b/src/pages/QuestionPage/index.tsx
@@ -10,6 +10,7 @@ import useConfidentInput from '../../hooks/useConfidentInput';
 import { Song as SongInterface } from '../../definitions';
 import { Redirect } from 'react-router';
 import useFocusOnMount from '../../hooks/useFocusOnMount';
+import { useGnomon } from '../../hooks/useSundial';
 
 export default function QuestionPage() {
   const [questionInput, setQuestionInput] = useQuestionInput();
@@ -17,7 +18,9 @@ export default function QuestionPage() {
   const [songs, loading] = useSpotifySearch(confidentQuestionInput);
   const [selectedSong, setSelectedSong] = useState<SongInterface | null>(null);
   const focusOnMountProps = useFocusOnMount();
+  const [timeOfDay] = useGnomon();
 
+  if (timeOfDay !== 'day') return <Redirect to='/listens' />;
   if (selectedSong) return <Redirect push to={`/submit?id=${selectedSong.id}`} />;
   return (
     <Page>

--- a/src/pages/QuestionPage/index.tsx
+++ b/src/pages/QuestionPage/index.tsx
@@ -11,6 +11,7 @@ import { Song as SongInterface } from '../../definitions';
 import { Redirect } from 'react-router';
 import useFocusOnMount from '../../hooks/useFocusOnMount';
 import { useGnomon } from '../../hooks/useSundial';
+import useSubmittedAfterLastSunrise from '../../hooks/useSubmittedAfterLastSunrise';
 
 export default function QuestionPage() {
   const [questionInput, setQuestionInput] = useQuestionInput();
@@ -19,7 +20,9 @@ export default function QuestionPage() {
   const [selectedSong, setSelectedSong] = useState<SongInterface | null>(null);
   const focusOnMountProps = useFocusOnMount();
   const [timeOfDay] = useGnomon();
+  const submittedListenAfterLastSunrise = useSubmittedAfterLastSunrise();
 
+  if (submittedListenAfterLastSunrise) return <Redirect to='/listens' />;
   if (timeOfDay !== 'day') return <Redirect to='/listens' />;
   if (selectedSong) return <Redirect push to={`/submit?id=${selectedSong.id}`} />;
   return (

--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -14,6 +14,7 @@ import useSubmitListenForm from './useSubmitListenForm';
 import useSubmitListen from './useSubmitListen';
 import useSubmitStateMachine from './useSubmitStateMachine';
 import { Link } from 'react-router-dom';
+import { useGnomon } from '../../hooks/useSundial';
 
 export default function SubmitPage() {
   const queryParams = useQueryParams();
@@ -23,6 +24,7 @@ export default function SubmitPage() {
   const [name, note, setName, setNote, valid] = useSubmitListenForm();
   const [submit] = useSubmitListen();
   const [submitState, sendSubmitStateEvent] = useSubmitStateMachine();
+  const [timeOfDay] = useGnomon();
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -36,6 +38,7 @@ export default function SubmitPage() {
     sendSubmitStateEvent('SUCCESS');
   }
 
+  if (timeOfDay !== 'day') return <Redirect to='/listens' />;
   if (!songId) return <Redirect to='/question' />;
   if (submitState === 'success') return <Redirect push to='/listens' />;
   return (

--- a/src/pages/SubmitPage/index.tsx
+++ b/src/pages/SubmitPage/index.tsx
@@ -15,6 +15,7 @@ import useSubmitListen from './useSubmitListen';
 import useSubmitStateMachine from './useSubmitStateMachine';
 import { Link } from 'react-router-dom';
 import { useGnomon } from '../../hooks/useSundial';
+import useSubmittedAfterLastSunrise from '../../hooks/useSubmittedAfterLastSunrise';
 
 export default function SubmitPage() {
   const queryParams = useQueryParams();
@@ -25,6 +26,7 @@ export default function SubmitPage() {
   const [submit] = useSubmitListen();
   const [submitState, sendSubmitStateEvent] = useSubmitStateMachine();
   const [timeOfDay] = useGnomon();
+  const submittedAfterLastSunrise = useSubmittedAfterLastSunrise();
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -38,6 +40,7 @@ export default function SubmitPage() {
     sendSubmitStateEvent('SUCCESS');
   }
 
+  if (submittedAfterLastSunrise) return <Redirect to='/listens' />;
   if (timeOfDay !== 'day') return <Redirect to='/listens' />;
   if (!songId) return <Redirect to='/question' />;
   if (submitState === 'success') return <Redirect push to='/listens' />;

--- a/src/pages/SubmitPage/useSubmitListen.ts
+++ b/src/pages/SubmitPage/useSubmitListen.ts
@@ -11,9 +11,16 @@ const SUBMIT_LISTEN_MUTATION = gql`
   ${ListenFragment}
 `;
 
+const LAST_SUBMIT_QUERY = gql`
+  query LastSubmit {
+    lastSubmit
+  }
+`;
+
 export default function useSubmitListen() {
   const submitListenMutation = useMutation(SUBMIT_LISTEN_MUTATION);
   async function submit(name: string, songId: string, note: string) {
+    const submitTime = new Date();
     await submitListenMutation({
       variables: {
         listenInput: {
@@ -22,6 +29,16 @@ export default function useSubmitListen() {
           note,
           ianaTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone
         }
+      },
+      update: cache => {
+        const submitTimeIsoString = submitTime.toISOString();
+        localStorage.setItem('lastSubmit', submitTimeIsoString);
+        cache.writeQuery({
+          query: LAST_SUBMIT_QUERY,
+          data: {
+            lastSubmit: submitTimeIsoString
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
Some routes should only be accessible under certain conditions. E.g., a
user shouldn't be able to visit the Question Page during the night or if
the user has already submitted a listen that day.

This PR also includes:
- Minor refactor to `ProgressBarLoader` (0fcdbf7)
- `lastSubmit` saved to cache and `localStorage` (8a2ca7e, e553975, 86ecedc)
- Minor refactor of sundial machine (e807a7a)
- Stop sending cypress recordings to the cypress dashboard (be9a13a)