### PR TITLE
Wait to show Loading CDs page

### DIFF
--- a/cypress/integration/LoadingCDsPage/steps.js
+++ b/cypress/integration/LoadingCDsPage/steps.js
@@ -12,7 +12,7 @@ Given('the internet is slow', () => {
 });
 
 Given('time is frozen', () => {
-  cy.clock();
+  cy.clock(new Date(), ['setInterval', 'clearInterval']);
 });
 
 Then(`the progress bar has the value {int}`, value => {

--- a/cypress/integration/LoadingCDsPage/steps.js
+++ b/cypress/integration/LoadingCDsPage/steps.js
@@ -1,6 +1,6 @@
 /* global cy */
 /// <reference types="cypress" />
-import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
 beforeEach(() => {
   cy.server();

--- a/cypress/integration/StoragePersistence.feature
+++ b/cypress/integration/StoragePersistence.feature
@@ -19,3 +19,12 @@ Feature: Storage Persistence
     And I visit "/question"
     And I wait for the page to load
     Then the browser sent the query "SunlightWindows" 2 times
+
+  Scenario: Loader doesn't show on quick cache startup
+    Given it is day
+    When I visit "/question"
+    And I see the loading cds page
+    And I wait for the page to load
+    And I leave the page
+    And I visit "/question"
+    Then I don't see the loading cds page

--- a/cypress/integration/StoragePersistence/steps.js
+++ b/cypress/integration/StoragePersistence/steps.js
@@ -38,5 +38,7 @@ Then(/the browser sent the query "(\w+)" (\d+) times?/, (operationName, numCalls
 
 Then(/I (don't )see the loading cds page/, dont => {
   const prefix = dont && 'not.';
-  cy.get('div[data-test=loading-cds-page]', { timeout: 50 }).should(`${prefix}be.visible`);
+  cy.get('div[data-test=loading-cds-page]', { timeout: dont ? 50 : 200 }).should(
+    `${prefix}be.visible`
+  );
 });

--- a/cypress/integration/StoragePersistence/steps.js
+++ b/cypress/integration/StoragePersistence/steps.js
@@ -38,7 +38,5 @@ Then(/the browser sent the query "(\w+)" (\d+) times?/, (operationName, numCalls
 
 Then(/I (don't )see the loading cds page/, dont => {
   const prefix = dont && 'not.';
-  cy.get('div[data-test=loading-cds-page]', { timeout: dont ? 50 : 200 }).should(
-    `${prefix}be.visible`
-  );
+  cy.get('div[data-test=loading-cds-page]', { timeout: 50 }).should(`${prefix}be.visible`);
 });

--- a/cypress/integration/StoragePersistence/steps.js
+++ b/cypress/integration/StoragePersistence/steps.js
@@ -3,13 +3,13 @@
 import { Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 beforeEach(() => {
-  cy.graphql();
+  cy.graphql({ delay: 1e3 });
   cy.server();
   cy.route('/accesstoken', 'fixture:morningcd/accessToken.json');
 });
 
 When('I wait for the page to load', () => {
-  cy.get('div[data-test=loading-cds-page]').should('not.exist');
+  cy.get('div[data-test=question-page]');
 });
 
 When('I refresh the page', () => {
@@ -19,6 +19,7 @@ When('I refresh the page', () => {
 When('I leave the page', () => {
   cy.window().then(window => {
     window.location.href = 'about:blank';
+    cy.wait(50); // fixes TypeError: Cannot read property 'attributes' of undefined
   });
 });
 
@@ -33,4 +34,9 @@ Then(/the browser sent the query "(\w+)" (\d+) times?/, (operationName, numCalls
   cy.graphqlNumCallsByOperationName().then(numCallsByOperationName => {
     expect(numCallsByOperationName).to.have.property(operationName, numCalls);
   });
+});
+
+Then(/I (don't )see the loading cds page/, dont => {
+  const prefix = dont && 'not.';
+  cy.get('div[data-test=loading-cds-page]', { timeout: 50 }).should(`${prefix}be.visible`);
 });

--- a/cypress/integration/Sundial.feature
+++ b/cypress/integration/Sundial.feature
@@ -19,7 +19,6 @@ Feature: Sundial
     Given the current local datetime in new york is "2019-05-03 <time>"
     When I visit "/question"
     Then the sundial is set to calibrating
-    And I see the loading cds page
     Then the sundial is set to <timeOfDay>
 
     Examples:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ApolloProvider } from 'react-apollo-hooks';
 import { Switch, Route, BrowserRouter as Router, Redirect } from 'react-router-dom';
 import { ThemeProvider } from './custom/styled-components';
@@ -14,11 +14,20 @@ import LoadingCDsPage from './pages/LoadingCDsPage';
 function App() {
   useSundial();
   const [timeOfDay] = useGnomon();
+  const [startThrottleDone, setStartThrottleDone] = useState(false);
+  useEffect(() => {
+    if (!startThrottleDone) {
+      const timeout = setTimeout(() => {
+        setStartThrottleDone(true);
+      }, 200);
+      return () => clearTimeout(timeout);
+    }
+  }, [startThrottleDone]);
   return (
     <div data-time-of-day={timeOfDay}>
       <GlobalStyle />
       {timeOfDay === 'calibrating' ? (
-        <LoadingCDsPage />
+        startThrottleDone && <LoadingCDsPage />
       ) : (
         <Router>
           <Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,20 +14,20 @@ import LoadingCDsPage from './pages/LoadingCDsPage';
 function App() {
   useSundial();
   const [timeOfDay] = useGnomon();
-  const [startThrottleDone, setStartThrottleDone] = useState(false);
+  const [showLoadingPageDelayDone, setShowLoadingPageDelayDone] = useState(false);
   useEffect(() => {
-    if (!startThrottleDone) {
+    if (!showLoadingPageDelayDone) {
       const timeout = setTimeout(() => {
-        setStartThrottleDone(true);
+        setShowLoadingPageDelayDone(true);
       }, 50);
       return () => clearTimeout(timeout);
     }
-  }, [startThrottleDone]);
+  }, [showLoadingPageDelayDone]);
   return (
     <div data-time-of-day={timeOfDay}>
       <GlobalStyle />
       {timeOfDay === 'calibrating' ? (
-        startThrottleDone && <LoadingCDsPage />
+        showLoadingPageDelayDone && <LoadingCDsPage />
       ) : (
         <Router>
           <Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     if (!startThrottleDone) {
       const timeout = setTimeout(() => {
         setStartThrottleDone(true);
-      }, 200);
+      }, 50);
       return () => clearTimeout(timeout);
     }
   }, [startThrottleDone]);

--- a/src/pages/QuestionPage/index.tsx
+++ b/src/pages/QuestionPage/index.tsx
@@ -26,7 +26,7 @@ export default function QuestionPage() {
   if (timeOfDay !== 'day') return <Redirect to='/listens' />;
   if (selectedSong) return <Redirect push to={`/submit?id=${selectedSong.id}`} />;
   return (
-    <Page>
+    <Page data-test='question-page'>
       <Title>What was the first piece of music you listened to this morning?</Title>
       <QuestionContainer>
         <Input.Text


### PR DESCRIPTION
#11 added persisting some state to local storage (at the moment, just the sunlight windows for the user.) The site now loads super quickly on refreshes (since sunlight windows don't have to be fetched from the server). When the page loads quickly from the cache, the loading cds page shows up for a blip, which looks bad, so this PR adds logic to wait 200 ms before showing the loading cds page on startup.